### PR TITLE
Allow for support with GKE and other providers

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 	"sigs.k8s.io/kustomize/kyaml/kio"


### PR DESCRIPTION
When using GKE or other providers, you may receive the following error:
```
Could not create Kubernetes ThirdPartyResource API client: No Auth Provider found for name "gcp"
```

Taking the solution from https://github.com/kubernetes/client-go/issues/242 - resolves this issue.